### PR TITLE
Adding monthly rebuild trigger

### DIFF
--- a/.github/workflows/monthly-rebuild.yml
+++ b/.github/workflows/monthly-rebuild.yml
@@ -1,0 +1,12 @@
+name: Monthly Rebuild
+on:
+  schedule:
+    - cron: '0 5 1 * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Request Netlify Webhook
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -X POST -d {} ${{ secrets.NETLIFY_BUILD_HOOK }}


### PR DESCRIPTION
At the start of the month the homepage's default month changes. I could handle this with JavaScript, but I think for now I'll just trigger a rebuild with a cron.