### PR TITLE
Fixing current day being shown as past

### DIFF
--- a/frontend/javascript/components/calendar-day.js
+++ b/frontend/javascript/components/calendar-day.js
@@ -13,7 +13,7 @@ export default class CalendarDay extends React.Component {
   }
 
   _dayHasPast() {
-    return this._date() < DateTime.local();
+    return this._date() < DateTime.local() && !this._dayIsToday();
   }
 
   _dayHasEvents() {


### PR DESCRIPTION
I couldn't quite figure out how to compare dates in Luxon without the current time affecting it. Either way I found a nice work around.