### PR TITLE
Sorting events on the day by datetime

### DIFF
--- a/src/_partials/_calendar.erb
+++ b/src/_partials/_calendar.erb
@@ -42,6 +42,7 @@
         .events
         .docs
         .select { |event| (current_month.beginning_of_month..current_month.end_of_month).cover?(event[:date]) }
+        .sort_by { |event| event[:datetime] }
         .collect { |event| event.data.slice(:title, :datetime, :name, :external_url, :online_event) }
       %>
       <%= { current_month: current_month.iso8601, date_range: date_range, events: events }.to_json %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/325384/110245974-8ed5e280-7f5d-11eb-87ac-81e1499640e0.png)

It's kind of weird an event at 7am appears after the event at 10pm. So fixing that