### PR TITLE
Replace Ruby-World references with Ruby-Meetup-Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This pulls a list of Ruby Events which are currently happening & displays them o
 
 ## How it works
 
-Every few days, a [GitHub Action](https://github.com/MikeRogers0/Ruby-World/blob/main/.github/workflows/pull-latest-events.yml) runs the command:
+Every few days, a [GitHub Action](https://github.com/MikeRogers0/Ruby-Meetup-Calendar/blob/main/.github/workflows/pull-latest-events.yml) runs the command:
 
 ```bash
 $ bundle exec rake update_data:all
@@ -29,11 +29,11 @@ $ yarn start
 
 ### Adding groups
 
-Currently the events are stored in the [`src/_data/groups.yml`](https://github.com/MikeRogers0/Ruby-World/blob/main/src/_data/groups.yml) file. I want to add as many active communities as I can.
+Currently the events are stored in the [`src/_data/groups.yml`](https://github.com/MikeRogers0/Ruby-Meetup-Calendar/blob/main/src/_data/groups.yml) file. I want to add as many active communities as I can.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at [MikeRogers0/Ruby-World](https://github.com/MikeRogers0/Ruby-World). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at [MikeRogers0/Ruby-Meetup-Calendar](https://github.com/MikeRogers0/Ruby-Meetup-Calendar). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## Licence
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Ruby-World",
+  "name": "Ruby-Meetup-Calendar",
   "version": "1.0.0",
   "private": true,
   "scripts": {

--- a/src/_components/footer.liquid
+++ b/src/_components/footer.liquid
@@ -4,6 +4,6 @@
   </div>
 
   <div class="footer_support">
-    <a href="https://github.com/MikeRogers0/Ruby-World" target="_blank">Contribute via GitHub</a>
+    <a href="https://github.com/MikeRogers0/Ruby-Meetup-Calendar" target="_blank">Contribute via GitHub</a>
   </div>
 </footer>


### PR DESCRIPTION
I renamed the repo a few months back, but forgot to catch all the references. So fixing that!