### PR TITLE
Add WNB.rb to list of groups

### DIFF
--- a/src/_data/groups.yml
+++ b/src/_data/groups.yml
@@ -379,3 +379,16 @@
   github:
   website: https://ruby.nz/
   email: committee@ruby.nz
+
+- name: WNB.rb
+  source: Eventbrite
+  eventbrite_id: 32770260241
+  url: https://www.eventbrite.com/o/wnbrb-32770260241
+  twitter_handle: wnb_rb
+  slack:
+  discord:
+  youtube:
+  twitch:
+  github:
+  website:
+  email: womennonbinary.rb@gmail.com


### PR DESCRIPTION
Hello! @jemmaissroff and I recently started a new meetup for women and non-binary Rubyists called WNB.rb! This PR adds that group to the list of groups. We don't have our own website, just an Eventbrite page, a Twitter, and an email.

Thanks for maintaining this page! It's awesome!