### PR TITLE
Skip pulling meetups without a source

### DIFF
--- a/lib/posts_generator.rb
+++ b/lib/posts_generator.rb
@@ -2,7 +2,7 @@ require "yaml"
 
 class PostsGenerator
   def call
-    groups.each do |group|
+    groups.select { |group| group["source"].present? }.each do |group|
       Group.const_get(group["source"]).new(group).call
     end
   end


### PR DESCRIPTION
https://github.com/MikeRogers0/Ruby-Meetup-Calendar/runs/2242624445?check_suite_focus=true - I just noticed it hasn't updated in a while due to a meetup without a source, so fixing that.