### PR TITLE
Adding filter for Cincy.rb who share a meetup group with others

### DIFF
--- a/lib/posts_generator/group/meetup.rb
+++ b/lib/posts_generator/group/meetup.rb
@@ -6,7 +6,13 @@ class PostsGenerator::Group::Meetup < PostsGenerator::Group
   private
 
   def events
-    @events ||= source_data.collect { |event_data|
+    @events ||= source_data
+      .select { |event_data|
+        event_data["confirmCount"] > 1 && (
+          @group["meetup_filter"].nil? || event_data["title"].include?(@group["meetup_filter"]["title_includes"])
+        )
+      }
+      .collect { |event_data|
       Event.new(
         title: event_data["title"],
         datetime: Time.parse(event_data["servertime"]),

--- a/src/_data/groups.yml
+++ b/src/_data/groups.yml
@@ -72,6 +72,8 @@
 - name: Cincy.rb
   source: Meetup
   meetup_id: TechLife-Cincinnati
+  meetup_filter:
+    title_includes: "Cincy.rb"
   links:
     link: https://cincyrb.com/
     twitter: https://twitter.com/cincinnatirb

--- a/src/_data/groups.yml
+++ b/src/_data/groups.yml
@@ -73,7 +73,7 @@
   source: Meetup
   meetup_id: TechLife-Cincinnati
   meetup_filter:
-    title_includes: "Cincy.rb"
+    title_includes: Cincy.rb
   links:
     link: https://cincyrb.com/
     twitter: https://twitter.com/cincinnatirb

--- a/src/_events/2021-04-07-cincy-rb.md
+++ b/src/_events/2021-04-07-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-04-07
-datetime: '2021-04-07T19:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/277236393/
-online_event: true
-year_month: 2021-04
----

--- a/src/_events/2021-04-08-cincy-rb.md
+++ b/src/_events/2021-04-08-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-04-08
-datetime: '2021-04-08T18:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/277261558/
-online_event: true
-year_month: 2021-04
----

--- a/src/_events/2021-04-13-cincy-rb.md
+++ b/src/_events/2021-04-13-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-04-13
-datetime: '2021-04-13T18:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/rhfrmryccgbrb/
-online_event: false
-year_month: 2021-04
----

--- a/src/_events/2021-04-14-chicago-ruby.md
+++ b/src/_events/2021-04-14-chicago-ruby.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Chicago Ruby - 2021-04-14
-datetime: '2021-04-14T19:00:00-04:00'
-name: Chicago Ruby
-external_url: https://www.meetup.com/ChicagoRuby/events/xlfgcryccgbsb/
-online_event: false
-year_month: 2021-04
----

--- a/src/_events/2021-04-15-cincy-rb.md
+++ b/src/_events/2021-04-15-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-04-15
-datetime: '2021-04-15T18:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/275563316/
-online_event: true
-year_month: 2021-04
----

--- a/src/_events/2021-04-15-north-west-ruby-user-group.md
+++ b/src/_events/2021-04-15-north-west-ruby-user-group.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: North West Ruby User Group - 2021-04-15
-datetime: '2021-04-15T13:30:00-04:00'
-name: North West Ruby User Group
-external_url: https://www.meetup.com/North-West-Ruby-User-Group/events/jdlpqqyccgbtb/
-online_event: false
-year_month: 2021-04
----

--- a/src/_events/2021-04-21-cincy-rb.md
+++ b/src/_events/2021-04-21-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-04-21
-datetime: '2021-04-21T11:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/277177393/
-online_event: false
-year_month: 2021-04
----

--- a/src/_events/2021-04-27-cincy-rb.md
+++ b/src/_events/2021-04-27-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-04-27
-datetime: '2021-04-27T18:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/277155702/
-online_event: true
-year_month: 2021-04
----

--- a/src/_events/2021-05-04-portland-ruby-brigade.md
+++ b/src/_events/2021-05-04-portland-ruby-brigade.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Portland Ruby Brigade - 2021-05-04
-datetime: '2021-05-04T21:00:00-04:00'
-name: Portland Ruby Brigade
-external_url: https://www.meetup.com/Portland-Ruby-Brigade/events/pbswdsycchbgb/
-online_event: false
-year_month: 2021-05
----

--- a/src/_events/2021-05-05-cincy-rb.md
+++ b/src/_events/2021-05-05-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-05-05
-datetime: '2021-05-05T19:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/276869729/
-online_event: true
-year_month: 2021-05
----

--- a/src/_events/2021-05-11-cincy-rb.md
+++ b/src/_events/2021-05-11-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-05-11
-datetime: '2021-05-11T18:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/rhfrmrycchbpb/
-online_event: false
-year_month: 2021-05
----

--- a/src/_events/2021-05-13-cincy-rb.md
+++ b/src/_events/2021-05-13-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-05-13
-datetime: '2021-05-13T18:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/xqzhdsycchbrb/
-online_event: false
-year_month: 2021-05
----

--- a/src/_events/2021-05-19-cincy-rb.md
+++ b/src/_events/2021-05-19-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-05-19
-datetime: '2021-05-19T11:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/lrctqqycchbzb/
-online_event: false
-year_month: 2021-05
----

--- a/src/_events/2021-05-20-cincy-rb.md
+++ b/src/_events/2021-05-20-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-05-20
-datetime: '2021-05-20T18:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/276555050/
-online_event: false
-year_month: 2021-05
----

--- a/src/_events/2021-05-20-north-west-ruby-user-group.md
+++ b/src/_events/2021-05-20-north-west-ruby-user-group.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: North West Ruby User Group - 2021-05-20
-datetime: '2021-05-20T13:30:00-04:00'
-name: North West Ruby User Group
-external_url: https://www.meetup.com/North-West-Ruby-User-Group/events/jdlpqqycchbbc/
-online_event: false
-year_month: 2021-05
----

--- a/src/_events/2021-05-25-cincy-rb.md
+++ b/src/_events/2021-05-25-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-05-25
-datetime: '2021-05-25T18:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/rmlmdsycchbhc/
-online_event: false
-year_month: 2021-05
----

--- a/src/_events/2021-06-01-portland-ruby-brigade.md
+++ b/src/_events/2021-06-01-portland-ruby-brigade.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Portland Ruby Brigade - 2021-06-01
-datetime: '2021-06-01T21:00:00-04:00'
-name: Portland Ruby Brigade
-external_url: https://www.meetup.com/Portland-Ruby-Brigade/events/pbswdsyccjbcb/
-online_event: false
-year_month: 2021-06
----

--- a/src/_events/2021-06-02-cincy-rb.md
+++ b/src/_events/2021-06-02-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-06-02
-datetime: '2021-06-02T19:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/bjxvdsyccjbdb/
-online_event: false
-year_month: 2021-06
----

--- a/src/_events/2021-06-08-cincy-rb.md
+++ b/src/_events/2021-06-08-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-06-08
-datetime: '2021-06-08T18:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/rhfrmryccjblb/
-online_event: false
-year_month: 2021-06
----

--- a/src/_events/2021-06-10-cincy-rb.md
+++ b/src/_events/2021-06-10-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-06-10
-datetime: '2021-06-10T18:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/xqzhdsyccjbnb/
-online_event: false
-year_month: 2021-06
----

--- a/src/_events/2021-06-16-cincy-rb.md
+++ b/src/_events/2021-06-16-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-06-16
-datetime: '2021-06-16T11:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/lrctqqyccjbvb/
-online_event: false
-year_month: 2021-06
----

--- a/src/_events/2021-06-17-cincy-rb.md
+++ b/src/_events/2021-06-17-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-06-17
-datetime: '2021-06-17T18:30:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/hjjlrryccjbwb/
-online_event: false
-year_month: 2021-06
----

--- a/src/_events/2021-06-22-cincy-rb.md
+++ b/src/_events/2021-06-22-cincy-rb.md
@@ -1,9 +1,0 @@
----
-layout: post
-title: Cincy.rb - 2021-06-22
-datetime: '2021-06-22T18:00:00-04:00'
-name: Cincy.rb
-external_url: https://www.meetup.com/TechLife-Cincinnati/events/rmlmdsyccjbdc/
-online_event: false
-year_month: 2021-06
----


### PR DESCRIPTION
I noticed Cincy.rb shares their meetup page with some other meetups, which meant we had a few Java meetups sneaking in :D 

So I added a way to filter meetup groups to ensure they include something in the title. I might need to make it more generic in the future.