### PR TITLE
Fixing navigation icons margins from icons

### DIFF
--- a/frontend/styles/components/btn.css
+++ b/frontend/styles/components/btn.css
@@ -20,7 +20,7 @@
 .btn > [data-feather] {
   display: inline-block;
   vertical-align: bottom;
-  margin-right: var(--spacing-1);
+  margin: 0;
 }
 
 .btn--disabled {
@@ -48,4 +48,7 @@
     color: var(--text-primary);
     background-color: var(--background-secondary-dark);
   }
+}
+.btn--navbar > [data-feather] {
+  margin-right: var(--spacing-1);
 }

--- a/frontend/styles/components/calendar.css
+++ b/frontend/styles/components/calendar.css
@@ -20,6 +20,7 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--spacing-2);
+  padding-right: 0;
   padding-top: 0;
 }
 
@@ -32,4 +33,5 @@
   display: inline-block;
   font-size: var(--font-size-6);
   line-height: var(--line-height-6);
+  margin-left: var(--spacing-1);
 }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/325384/117539447-99b2ff00-b002-11eb-8fc5-921004c287a3.png)

After:

![image](https://user-images.githubusercontent.com/325384/117539457-a2a3d080-b002-11eb-8628-fb684571c9fc.png)

The feather icons had a margin on them, which made the button bigger then it should be. All sorted now.