### PR TITLE
Removing future events when adding new events

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ end
 namespace :update_data do
   desc "Updates the currently known events & converts them into posts"
   task all: :environment do
+    Events::FutureClearer.new.call
     PostsGenerator.new.call
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ task :environment do
   require "dotenv/load"
 
   require "./lib/event"
+  require "./lib/events"
   require "./lib/groups_sorter"
   require "./lib/posts_generator"
 end

--- a/lib/events.rb
+++ b/lib/events.rb
@@ -1,5 +1,5 @@
-require "./events/reformatter"
-require "./events/future_clearer"
-
 module Events
 end
+
+require "./lib/events/future_clearer"
+require "./lib/events/reformatter"

--- a/lib/events.rb
+++ b/lib/events.rb
@@ -1,0 +1,5 @@
+require "./events/reformatter"
+require "./events/future_clearer"
+
+module Events
+end

--- a/lib/events/future_clearer.rb
+++ b/lib/events/future_clearer.rb
@@ -1,0 +1,19 @@
+require "yaml"
+
+# This clears all future events, as sometimes they get cancelled / moved.
+class Events::FutureClearer
+  EVENTS_PATH = "src/_events/*.md"
+
+  def call
+    events.each do |event_path|
+      event_data = YAML.safe_load(File.open(event_path))
+      File.delete(event_path) if Time.parse(event_data["datetime"]) >= 1.day.from_now
+    end
+  end
+
+  private
+
+  def events
+    @events ||= Dir[EVENTS_PATH]
+  end
+end

--- a/lib/events/future_clearer.rb
+++ b/lib/events/future_clearer.rb
@@ -1,19 +1,21 @@
 require "yaml"
 
-# This clears all future events, as sometimes they get cancelled / moved.
-class Events::FutureClearer
-  EVENTS_PATH = "src/_events/*.md"
+module Events
+  # This clears all future events, as sometimes they get cancelled / moved.
+  class FutureClearer
+    EVENTS_PATH = "src/_events/*.md"
 
-  def call
-    events.each do |event_path|
-      event_data = YAML.safe_load(File.open(event_path))
-      File.delete(event_path) if Time.parse(event_data["datetime"]) >= 1.day.from_now
+    def call
+      events.each do |event_path|
+        event_data = YAML.safe_load(File.open(event_path))
+        File.delete(event_path) if Time.parse(event_data["datetime"]) >= 1.day.from_now
+      end
     end
-  end
 
-  private
+    private
 
-  def events
-    @events ||= Dir[EVENTS_PATH]
+    def events
+      @events ||= Dir[EVENTS_PATH]
+    end
   end
 end

--- a/lib/events/reformatter.rb
+++ b/lib/events/reformatter.rb
@@ -1,9 +1,6 @@
 require "yaml"
-require "active_support"
-require "active_support/core_ext"
-require "./lib/event"
 
-class EventsReformatter
+class Events::Reformatter
   EVENTS_PATH = "src/_events/*.md"
 
   def call

--- a/lib/events/reformatter.rb
+++ b/lib/events/reformatter.rb
@@ -1,24 +1,26 @@
 require "yaml"
 
-class Events::Reformatter
-  EVENTS_PATH = "src/_events/*.md"
+module Events
+  class Reformatter
+    EVENTS_PATH = "src/_events/*.md"
 
-  def call
-    events.each do |event_path|
-      event_data = YAML.safe_load(File.open(event_path))
-      Event.new(
-        title: event_data["title"],
-        datetime: Time.parse(event_data["datetime"]),
-        url: event_data["external_url"],
-        name: event_data["name"],
-        online_event: event_data["online_event"]
-      ).save
+    def call
+      events.each do |event_path|
+        event_data = YAML.safe_load(File.open(event_path))
+        Event.new(
+          title: event_data["title"],
+          datetime: Time.parse(event_data["datetime"]),
+          url: event_data["external_url"],
+          name: event_data["name"],
+          online_event: event_data["online_event"]
+        ).save
+      end
     end
-  end
 
-  private
+    private
 
-  def events
-    @events ||= Dir[EVENTS_PATH]
+    def events
+      @events ||= Dir[EVENTS_PATH]
+    end
   end
 end

--- a/lib/posts_generator.rb
+++ b/lib/posts_generator.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require "./lib/posts_generator/group"
 
 class PostsGenerator
   def call
@@ -13,5 +14,3 @@ class PostsGenerator
     @groups ||= YAML.safe_load(File.open("src/_data/groups.yml"))
   end
 end
-
-require "./lib/posts_generator/group"

--- a/lib/posts_generator.rb
+++ b/lib/posts_generator.rb
@@ -1,5 +1,4 @@
 require "yaml"
-require "./lib/posts_generator/group"
 
 class PostsGenerator
   def call
@@ -14,3 +13,5 @@ class PostsGenerator
     @groups ||= YAML.safe_load(File.open("src/_data/groups.yml"))
   end
 end
+
+require "./lib/posts_generator/group"


### PR DESCRIPTION
Closes https://github.com/MikeRogers0/Ruby-Meetup-Calendar/issues/47

Instead of checking if they're 404'ing, just remove future events before we add any new events. This should handle any renames/cancellations also. 